### PR TITLE
fixed kARAAPIGeneration_2_X spelling

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,7 +3,7 @@ This is a development build of the ARA Library 2.1.
 
 
 ARA SDK 2.1 draft 1 (aka 2.0.1) (2021/??/??)
-- no changes yet
+- initial draft of ARA audio file chunk authoring directly in the host
 
 
 === ARA SDK 2.0 release (aka 2.0.001) (2021/05/03) ===

--- a/Debug/ARADebug.c
+++ b/Debug/ARADebug.c
@@ -135,9 +135,9 @@ static ARABool IsDebuggerAttached(void)
     #if !defined(BreakIntoDebugger)
         // GDB: signal SIGINT to have the debugger stop directly at the expression
         // see https://cocoawithlove.com/2008/03/break-into-debugger.html
-        #if (defined(__ppc__) || defined(__ppc64__))
-            #define BreakIntoDebugger(...) __asm__ volatile("li r0,20\n  sc\n  nop\n  li r0,37\n  li r4,2\n  sc\n  nop\n" : : : "memory","r0","r4")
-        #elif (defined(__i386__) || defined(__x86_64__))
+//      #if ARA_CPU_PPC
+//          #define BreakIntoDebugger(...) __asm__ volatile("li r0,20\n  sc\n  nop\n  li r0,37\n  li r4,2\n  sc\n  nop\n" : : : "memory","r0","r4")
+        #if ARA_CPU_X86
             #define BreakIntoDebugger(...) __asm__ volatile("int $3\n  nop\n" : : )
         #else
             #warning "BreakIntoDebugger() not yet implemented for this processor, falling back to __builtin_trap() which aborts the program."

--- a/Debug/ARADebug.h
+++ b/Debug/ARADebug.h
@@ -69,7 +69,8 @@ extern "C"
         // logs to the debugger console and/or to the error output (e.g. stderr)
         void ARADebugMessage(ARADebugLevel level, const char * file, int line, const char * text, ...);
         // this logging can be prefixed by a custom static string if desired, which is useful e.g.
-        // if multiple plug-ins are build using the same compiled library, or in the IPC Demo example
+        // if multiple plug-ins are build using the same compiled library, or if using the IPC
+        // capabilities of the ARATestHost example
         // typically, this setup call is made once when loading the final binary and passes its name
         void ARASetupDebugMessagePrefix(const char * prefix);
         #if defined(__cplusplus)

--- a/Dispatch/ARAHostDispatch.cpp
+++ b/Dispatch/ARAHostDispatch.cpp
@@ -828,7 +828,7 @@ namespace ARA1EditorViewAdapterDispatcher
     static void ARA_CALL notifySelection (ARAEditorViewRef /*editorViewRef*/, const ARAViewSelection* /*selection*/)
     {}
 
-    static void ARA_CALL notifyHideRegionSequences (ARAEditorViewRef /*editorViewRef*/, ARASize /*regionSequencesCount*/, const ARARegionSequenceRef /*regionSequenceRefs*/[])
+    static void ARA_CALL notifyHideRegionSequences (ARAEditorViewRef /*editorViewRef*/, ARASize /*regionSequenceRefsCount*/, const ARARegionSequenceRef /*regionSequenceRefs*/[])
     {}
 
     static const ARAEditorViewInterface* getInterface () noexcept
@@ -854,9 +854,9 @@ void EditorView::notifySelection (const ARAViewSelection* selection) noexcept
     getInterface ()->notifySelection (getRef (), selection);
 }
 
-void EditorView::notifyHideRegionSequences (ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
+void EditorView::notifyHideRegionSequences (ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
 {
-    getInterface ()->notifyHideRegionSequences (getRef (), regionSequencesCount, regionSequenceRefs);
+    getInterface ()->notifyHideRegionSequences (getRef (), regionSequenceRefsCount, regionSequenceRefs);
 }
 
 }   // namespace Host

--- a/Dispatch/ARAHostDispatch.cpp
+++ b/Dispatch/ARAHostDispatch.cpp
@@ -420,6 +420,28 @@ bool DocumentController::storeObjectsToArchive (ARAArchiveWriterHostRef writerHo
     return (getInterface ()->storeObjectsToArchive (getRef (), writerHostRef, filter) != kARAFalse);
 }
 
+bool DocumentController::supportsStoringAudioFileChunks () noexcept
+{
+    if (!getInterface ().implements<ARA_STRUCT_MEMBER (ARADocumentControllerInterface, storeAudioSourceToAudioFileChunk)> ())
+        return false;
+
+    const SizedStructPtr<ARAFactory> factory { getInterface ()->getFactory (getRef ()) };
+    if (!factory.implements<ARA_STRUCT_MEMBER (ARAFactory, supportsStoringAudioFileChunks)> ())
+        return false;
+    return (factory->supportsStoringAudioFileChunks != kARAFalse);
+}
+
+bool DocumentController::storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept
+{
+    if (!supportsStoringAudioFileChunks ())
+        return false;
+
+    ARABool autoOpen { kARAFalse };
+    const auto result { getInterface ()->storeAudioSourceToAudioFileChunk (getRef (), writerHostRef, audioSourceRef, documentArchiveID, &autoOpen) };
+    *openAutomatically = (autoOpen != kARAFalse);
+    return (result != kARAFalse);
+}
+
 ARAMusicalContextRef DocumentController::createMusicalContext (ARAMusicalContextHostRef hostRef, const ARAMusicalContextProperties* properties) noexcept
 {
     return getInterface ()->createMusicalContext (getRef (), hostRef, properties);

--- a/Dispatch/ARAHostDispatch.h
+++ b/Dispatch/ARAHostDispatch.h
@@ -120,9 +120,9 @@ public:
     //! \copydoc ARAAudioAccessControllerInterface::createAudioReaderForSource
     virtual ARAAudioReaderHostRef createAudioReaderForSource (ARAAudioSourceHostRef audioSourceHostRef, bool use64BitSamples) noexcept = 0;
     //! \copydoc ARAAudioAccessControllerInterface::readAudioSamples
-    virtual bool readAudioSamples (ARAAudioReaderHostRef readerRef, ARASamplePosition samplePosition, ARASampleCount samplesPerChannel, void* const buffers[]) noexcept = 0;
+    virtual bool readAudioSamples (ARAAudioReaderHostRef audioReaderHostRef, ARASamplePosition samplePosition, ARASampleCount samplesPerChannel, void* const buffers[]) noexcept = 0;
     //! \copydoc ARAAudioAccessControllerInterface::destroyAudioReader
-    virtual void destroyAudioReader (ARAAudioReaderHostRef readerRef) noexcept = 0;
+    virtual void destroyAudioReader (ARAAudioReaderHostRef audioReaderHostRef) noexcept = 0;
 };
 ARA_MAP_HOST_REF (AudioAccessControllerInterface, ARAAudioAccessControllerHostRef)
 
@@ -309,23 +309,23 @@ public:
 //@{
     // deprecated ARA 1 monolithic persistency calls, must be used unless requiring plug-ins to support kARAAPIGeneration_2_0_Final
     //! \copydoc ARADocumentControllerInterface::beginRestoringDocumentFromArchive
-    ARA_DEPRECATED(2_0_Final) bool beginRestoringDocumentFromArchive (ARAArchiveReaderHostRef readerHostRef) noexcept;
+    ARA_DEPRECATED(2_0_Final) bool beginRestoringDocumentFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef) noexcept;
     //! \copydoc ARADocumentControllerInterface::endRestoringDocumentFromArchive
-    ARA_DEPRECATED(2_0_Final) bool endRestoringDocumentFromArchive (ARAArchiveReaderHostRef readerHostRef) noexcept;
+    ARA_DEPRECATED(2_0_Final) bool endRestoringDocumentFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef) noexcept;
     //! \copydoc ARADocumentControllerInterface::storeDocumentToArchive
-    ARA_DEPRECATED(2_0_Final) bool storeDocumentToArchive (ARAArchiveWriterHostRef writerHostRef) noexcept;
+    ARA_DEPRECATED(2_0_Final) bool storeDocumentToArchive (ARAArchiveWriterHostRef archiveWriterHostRef) noexcept;
     //! If supporting both types of persistency, this call can be used to pick the appropriate type for the given plug-in.
     ARA_DEPRECATED(2_0_Final) bool supportsPartialPersistency () noexcept;
     // new ARA 2 partial persistency calls, may only be used for plug-ins that support the new ARA 2 persistency,
     // which is part of kARAAPIGeneration_2_0_Final (but not yet present in kARAAPIGeneration_2_0_Draft !)
     //! \copydoc ARADocumentControllerInterface::restoreObjectsFromArchive
-    bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept;
+    bool restoreObjectsFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef, const ARARestoreObjectsFilter* filter) noexcept;
     //! \copydoc ARADocumentControllerInterface::storeObjectsToArchive
-    bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept;
+    bool storeObjectsToArchive (ARAArchiveWriterHostRef archiveWriterHostRef, const ARAStoreObjectsFilter* filter) noexcept;
     //! Test whether storeAudioSourceToAudioFileChunk () is supported by the plug-in.
     bool supportsStoringAudioFileChunks () noexcept;
     //! \copydoc ARADocumentControllerInterface::storeAudioSourceToAudioFileChunk
-    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept;
+    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef archiveWriterHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept;
 //@}
 
 //! @name Document Management

--- a/Dispatch/ARAHostDispatch.h
+++ b/Dispatch/ARAHostDispatch.h
@@ -46,6 +46,10 @@ namespace Host {
     #define ARA_SUPPORT_VERSION_1 0
 #endif
 
+#if ARA_SUPPORT_VERSION_1 && ARA_CPU_ARM
+    #error "ARA v1 is not supported on ARM architecture"
+#endif
+
 /*******************************************************************************/
 /** Type safe conversions to/from host ref: toHostRef () and fromHostRef<> ().
     This macro defines custom overloads of the toHostRef () and fromHostRef<> () conversion functions

--- a/Dispatch/ARAHostDispatch.h
+++ b/Dispatch/ARAHostDispatch.h
@@ -560,7 +560,7 @@ public:
     //! \copydoc ARAEditorViewInterface::notifySelection
     void notifySelection (const ARAViewSelection* selection) noexcept;
     //! \copydoc ARAEditorViewInterface::notifyHideRegionSequences
-    void notifyHideRegionSequences (ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept;
+    void notifyHideRegionSequences (ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept;
 //@}
 };
 

--- a/Dispatch/ARAHostDispatch.h
+++ b/Dispatch/ARAHostDispatch.h
@@ -322,6 +322,10 @@ public:
     bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept;
     //! \copydoc ARADocumentControllerInterface::storeObjectsToArchive
     bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept;
+    //! Test whether storeAudioSourceToAudioFileChunk () is supported by the plug-in.
+    bool supportsStoringAudioFileChunks () noexcept;
+    //! \copydoc ARADocumentControllerInterface::storeAudioSourceToAudioFileChunk
+    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept;
 //@}
 
 //! @name Document Management

--- a/Dispatch/ARAHostDispatch.h
+++ b/Dispatch/ARAHostDispatch.h
@@ -84,7 +84,7 @@ namespace Host {
 #endif
 
 /*******************************************************************************/
-/** Tag objects maintained by the plug-in to prevent accidently copying/moving them. */
+/** Tag objects maintained by the plug-in to prevent accidentally copying/moving them. */
 /*******************************************************************************/
 
 #if !defined (ARA_PLUGIN_MANAGED_OBJECT)

--- a/Dispatch/ARAPlugInDispatch.cpp
+++ b/Dispatch/ARAPlugInDispatch.cpp
@@ -325,9 +325,17 @@ namespace DocumentControllerDispatcher
         return (fromRef (controllerRef)->isLicensedForCapabilities (runModalActivationDialogIfNeeded != kARAFalse, contentTypesCount, contentTypes, transformationFlags)) ? kARATrue : kARAFalse;
     }
 
+    static ARABool ARA_CALL storeAudioSourceToAudioFileChunk (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, ARABool* openAutomatically) noexcept
+    {
+        bool autoOpen { false };
+        const auto result {fromRef (controllerRef)->storeAudioSourceToAudioFileChunk (writerHostRef, audioSourceRef, documentArchiveID, &autoOpen) };
+        *openAutomatically = (autoOpen) ? kARATrue : kARAFalse;
+        return (result) ? kARATrue : kARAFalse;
+    }
+
     static const ARADocumentControllerInterface* getInterface () noexcept
     {
-        static const SizedStruct<ARA_STRUCT_MEMBER (ARADocumentControllerInterface, isLicensedForCapabilities)> ifc =
+        static const SizedStruct<ARA_STRUCT_MEMBER (ARADocumentControllerInterface, storeAudioSourceToAudioFileChunk)> ifc =
         {
             DocumentControllerDispatcher::destroyDocumentController,
             DocumentControllerDispatcher::getFactory,
@@ -380,7 +388,8 @@ namespace DocumentControllerDispatcher
             DocumentControllerDispatcher::getProcessingAlgorithmProperties,
             DocumentControllerDispatcher::getProcessingAlgorithmForAudioSource,
             DocumentControllerDispatcher::requestProcessingAlgorithmForAudioSource,
-            DocumentControllerDispatcher::isLicensedForCapabilities
+            DocumentControllerDispatcher::isLicensedForCapabilities,
+            DocumentControllerDispatcher::storeAudioSourceToAudioFileChunk
         };
         return &ifc;
     }

--- a/Dispatch/ARAPlugInDispatch.cpp
+++ b/Dispatch/ARAPlugInDispatch.cpp
@@ -60,35 +60,35 @@ namespace DocumentControllerDispatcher
 
     // Archiving
 
-    static ARABool ARA_CALL beginRestoringDocumentFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef /*readerHostRef*/) noexcept
+    static ARABool ARA_CALL beginRestoringDocumentFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef /*archiveReaderHostRef*/) noexcept
     {
         // begin-/endRestoringDocumentFromArchive () is deprecated, but can be fully mapped to supported calls
         fromRef (controllerRef)->beginEditing ();
         return kARATrue;
     }
 
-    static ARABool ARA_CALL endRestoringDocumentFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef readerHostRef) noexcept
+    static ARABool ARA_CALL endRestoringDocumentFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef archiveReaderHostRef) noexcept
     {
         // begin-/endRestoringDocumentFromArchive () is deprecated, but can be fully mapped to supported calls
-        const auto result { fromRef (controllerRef)->restoreObjectsFromArchive (readerHostRef, nullptr) };
+        const auto result { fromRef (controllerRef)->restoreObjectsFromArchive (archiveReaderHostRef, nullptr) };
         fromRef (controllerRef)->endEditing ();
         return (result) ? kARATrue : kARAFalse;
     }
 
-    static ARABool ARA_CALL storeDocumentToArchive (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef writerHostRef) noexcept
+    static ARABool ARA_CALL storeDocumentToArchive (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef archiveWriterHostRef) noexcept
     {
         // storeDocumentToArchive () is deprecated, but can be fully mapped to supported calls
-        return (fromRef (controllerRef)->storeObjectsToArchive (writerHostRef, nullptr)) ? kARATrue : kARAFalse;
+        return (fromRef (controllerRef)->storeObjectsToArchive (archiveWriterHostRef, nullptr)) ? kARATrue : kARAFalse;
     }
 
-    static ARABool ARA_CALL restoreObjectsFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept
+    static ARABool ARA_CALL restoreObjectsFromArchive (ARADocumentControllerRef controllerRef, ARAArchiveReaderHostRef archiveReaderHostRef, const ARARestoreObjectsFilter* filter) noexcept
     {
-        return (fromRef (controllerRef)->restoreObjectsFromArchive (readerHostRef, filter)) ? kARATrue : kARAFalse;
+        return (fromRef (controllerRef)->restoreObjectsFromArchive (archiveReaderHostRef, filter)) ? kARATrue : kARAFalse;
     }
 
-    static ARABool ARA_CALL storeObjectsToArchive (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept
+    static ARABool ARA_CALL storeObjectsToArchive (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef archiveWriterHostRef, const ARAStoreObjectsFilter* filter) noexcept
     {
-        return (fromRef (controllerRef)->storeObjectsToArchive (writerHostRef, filter)) ? kARATrue : kARAFalse;
+        return (fromRef (controllerRef)->storeObjectsToArchive (archiveWriterHostRef, filter)) ? kARATrue : kARAFalse;
     }
 
     // Document Management
@@ -325,10 +325,10 @@ namespace DocumentControllerDispatcher
         return (fromRef (controllerRef)->isLicensedForCapabilities ((runModalActivationDialogIfNeeded != kARAFalse), contentTypesCount, contentTypes, transformationFlags)) ? kARATrue : kARAFalse;
     }
 
-    static ARABool ARA_CALL storeAudioSourceToAudioFileChunk (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, ARABool* openAutomatically) noexcept
+    static ARABool ARA_CALL storeAudioSourceToAudioFileChunk (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef archiveWriterHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, ARABool* openAutomatically) noexcept
     {
         bool autoOpen { false };
-        const auto result {fromRef (controllerRef)->storeAudioSourceToAudioFileChunk (writerHostRef, audioSourceRef, documentArchiveID, &autoOpen) };
+        const auto result {fromRef (controllerRef)->storeAudioSourceToAudioFileChunk (archiveWriterHostRef, audioSourceRef, documentArchiveID, &autoOpen) };
         *openAutomatically = (autoOpen) ? kARATrue : kARAFalse;
         return (result) ? kARATrue : kARAFalse;
     }
@@ -580,15 +580,15 @@ ARAAudioReaderHostRef HostAudioAccessController::createAudioReaderForSource (ARA
     return getInterface ()->createAudioReaderForSource (getRef (), audioSourceHostRef, (use64BitSamples) ? kARATrue : kARAFalse);
 }
 
-bool HostAudioAccessController::readAudioSamples (ARAAudioReaderHostRef readerRef,
+bool HostAudioAccessController::readAudioSamples (ARAAudioReaderHostRef audioReaderHostRef,
                                                  ARASamplePosition samplePosition, ARASampleCount samplesPerChannel, void* const buffers[]) noexcept
 {
-    return (getInterface ()->readAudioSamples (getRef (), readerRef, samplePosition, samplesPerChannel, buffers) != kARAFalse);
+    return (getInterface ()->readAudioSamples (getRef (), audioReaderHostRef, samplePosition, samplesPerChannel, buffers) != kARAFalse);
 }
 
-void HostAudioAccessController::destroyAudioReader (ARAAudioReaderHostRef readerRef) noexcept
+void HostAudioAccessController::destroyAudioReader (ARAAudioReaderHostRef audioReaderHostRef) noexcept
 {
-    getInterface ()->destroyAudioReader (getRef (), readerRef);
+    getInterface ()->destroyAudioReader (getRef (), audioReaderHostRef);
 }
 
 /*******************************************************************************/

--- a/Dispatch/ARAPlugInDispatch.cpp
+++ b/Dispatch/ARAPlugInDispatch.cpp
@@ -322,7 +322,7 @@ namespace DocumentControllerDispatcher
 
     static ARABool ARA_CALL isLicensedForCapabilities (ARADocumentControllerRef controllerRef, ARABool runModalActivationDialogIfNeeded, ARASize contentTypesCount, const ARAContentType contentTypes[], ARAPlaybackTransformationFlags transformationFlags) noexcept
     {
-        return (fromRef (controllerRef)->isLicensedForCapabilities (runModalActivationDialogIfNeeded != kARAFalse, contentTypesCount, contentTypes, transformationFlags)) ? kARATrue : kARAFalse;
+        return (fromRef (controllerRef)->isLicensedForCapabilities ((runModalActivationDialogIfNeeded != kARAFalse), contentTypesCount, contentTypes, transformationFlags)) ? kARATrue : kARAFalse;
     }
 
     static ARABool ARA_CALL storeAudioSourceToAudioFileChunk (ARADocumentControllerRef controllerRef, ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, ARABool* openAutomatically) noexcept

--- a/Dispatch/ARAPlugInDispatch.cpp
+++ b/Dispatch/ARAPlugInDispatch.cpp
@@ -480,9 +480,9 @@ namespace EditorViewDispatcher
         fromRef (editorViewRef)->notifySelection (selection);
     }
 
-    static void ARA_CALL notifyHideRegionSequences (ARAEditorViewRef editorViewRef, ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
+    static void ARA_CALL notifyHideRegionSequences (ARAEditorViewRef editorViewRef, ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
     {
-        fromRef (editorViewRef)->notifyHideRegionSequences (regionSequencesCount, regionSequenceRefs);
+        fromRef (editorViewRef)->notifyHideRegionSequences (regionSequenceRefsCount, regionSequenceRefs);
     }
 
     static const ARAEditorViewInterface* getInterface () noexcept

--- a/Dispatch/ARAPlugInDispatch.h
+++ b/Dispatch/ARAPlugInDispatch.h
@@ -131,11 +131,11 @@ public:
 //! @name Archiving
 //@{
     //! \copydoc ARADocumentControllerInterface::restoreObjectsFromArchive
-    virtual bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept = 0;
+    virtual bool restoreObjectsFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef, const ARARestoreObjectsFilter* filter) noexcept = 0;
     //! \copydoc ARADocumentControllerInterface::storeObjectsToArchive
-    virtual bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept = 0;
+    virtual bool storeObjectsToArchive (ARAArchiveWriterHostRef archiveWriterHostRef, const ARAStoreObjectsFilter* filter) noexcept = 0;
     //! \copydoc ARADocumentControllerInterface::storeAudioSourceToAudioFileChunk
-    virtual bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept = 0;
+    virtual bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef archiveWriterHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept = 0;
 //@}
 
 //! @name Document Management
@@ -385,10 +385,10 @@ public:
     //! \copydoc ARAAudioAccessControllerInterface::createAudioReaderForSource
     ARAAudioReaderHostRef createAudioReaderForSource (ARAAudioSourceHostRef audioSourceHostRef, bool use64BitSamples) noexcept;
     //! \copydoc ARAAudioAccessControllerInterface::readAudioSamples
-    bool readAudioSamples (ARAAudioReaderHostRef readerRef,
+    bool readAudioSamples (ARAAudioReaderHostRef audioReaderHostRef,
                            ARASamplePosition samplePosition, ARASampleCount samplesPerChannel, void* const buffers[]) noexcept;
     //! \copydoc ARAAudioAccessControllerInterface::destroyAudioReader
-    void destroyAudioReader (ARAAudioReaderHostRef readerRef) noexcept;
+    void destroyAudioReader (ARAAudioReaderHostRef audioReaderHostRef) noexcept;
 };
 
 /*******************************************************************************/

--- a/Dispatch/ARAPlugInDispatch.h
+++ b/Dispatch/ARAPlugInDispatch.h
@@ -134,6 +134,8 @@ public:
     virtual bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept = 0;
     //! \copydoc ARADocumentControllerInterface::storeObjectsToArchive
     virtual bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept = 0;
+    //! \copydoc ARADocumentControllerInterface::storeAudioSourceToAudioFileChunk
+    virtual bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept = 0;
 //@}
 
 //! @name Document Management

--- a/Dispatch/ARAPlugInDispatch.h
+++ b/Dispatch/ARAPlugInDispatch.h
@@ -330,7 +330,7 @@ public:
     //! \copydoc ARAEditorViewInterface::notifySelection
     virtual void notifySelection (SizedStructPtr<ARAViewSelection> selection) noexcept = 0;
     //! \copydoc ARAEditorViewInterface::notifyHideRegionSequences
-    virtual void notifyHideRegionSequences (ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept = 0;
+    virtual void notifyHideRegionSequences (ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept = 0;
 //@}
 };
 ARA_MAP_REF (EditorViewInterface, ARAEditorViewRef)

--- a/Dispatch/ARAPlugInDispatch.h
+++ b/Dispatch/ARAPlugInDispatch.h
@@ -41,6 +41,10 @@ namespace PlugIn {
     #define ARA_SUPPORT_VERSION_1 0
 #endif
 
+#if ARA_SUPPORT_VERSION_1 && ARA_CPU_ARM
+    #error "ARA v1 is not supported on ARM architecture"
+#endif
+
 /*******************************************************************************/
 /** Type safe conversions to/from ref: toRef () and fromRef<> ().
     This macro defines custom overloads of the toRef () and fromRef<> () conversion functions

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -1151,6 +1151,48 @@ bool DocumentController::storeObjectsToArchive (ARAArchiveWriterHostRef writerHo
     }
 }
 
+bool DocumentController::storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept
+{
+    ARA_LOG_HOST_ENTRY (this);
+    ARA_VALIDATE_API_ARGUMENT (this, isValidDocumentController (this));
+
+    auto audioSource { fromRef (audioSourceRef) };
+    ARA_VALIDATE_API_ARGUMENT (audioSourceRef, isValidAudioSource (audioSource));
+
+    ARA_VALIDATE_API_ARGUMENT (documentArchiveID, documentArchiveID != nullptr);
+    ARA_VALIDATE_API_ARGUMENT (openAutomatically, openAutomatically != nullptr);
+
+    ARA_VALIDATE_API_STATE (getFactory ()->supportsStoringAudioFileChunks != kARAFalse);
+    ARA_VALIDATE_API_STATE (!isHostEditingDocument ());
+    ARA_VALIDATE_API_STATE (_contentReaders.empty ());
+
+    HostArchiveWriter archiveWriter (this, writerHostRef);
+    *documentArchiveID = nullptr;
+    const auto result { doStoreAudioSourceToAudioFileChunk (&archiveWriter, audioSource, documentArchiveID, openAutomatically) };
+    ARA_INTERNAL_ASSERT (*documentArchiveID != nullptr);
+#if ARA_ENABLE_INTERNAL_ASSERTS
+    bool isValidID { *documentArchiveID == getFactory ()->documentArchiveID };
+    for (auto i { 0U }; !isValidID && (i < getFactory ()->compatibleDocumentArchiveIDsCount); ++i)
+        isValidID = (*documentArchiveID == getFactory ()->compatibleDocumentArchiveIDs[i]);
+    ARA_INTERNAL_ASSERT (isValidID);
+#endif
+    return result;
+}
+
+bool DocumentControllerDelegate::doStoreAudioSourceToAudioFileChunk (HostArchiveWriter* archiveWriter, AudioSource* audioSource, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept
+{
+    *documentArchiveID = getPlugInEntry ()->getFactory ()->documentArchiveID;
+    *openAutomatically = false;
+
+    ARAAudioSourceRef audioSourceRef { toRef (audioSource) };
+    const ARA::SizedStruct<ARA_STRUCT_MEMBER (ARAStoreObjectsFilter, audioModificationRefs)> filter { ARA::kARATrue,
+                                                                                                      1U, &audioSourceRef,
+                                                                                                      0U, nullptr
+                                                                                                    };
+    const StoreObjectsFilter storeObjectsFilter { &filter };
+    return doStoreObjectsToArchive (archiveWriter, &storeObjectsFilter);
+}
+
 void DocumentController::updateDocumentProperties (PropertiesPtr<ARADocumentProperties> properties) noexcept
 {
     ARA_LOG_HOST_ENTRY (this);
@@ -2650,7 +2692,8 @@ PlugInEntry::PlugInEntry (const FactoryConfig* factoryConfig,
                createDocumentControllerWithDocumentFunc,
                factoryConfig->getDocumentArchiveID (), factoryConfig->getCompatibleDocumentArchiveIDsCount (), factoryConfig->getCompatibleDocumentArchiveIDs (),
                factoryConfig->getAnalyzeableContentTypesCount (), factoryConfig->getAnalyzeableContentTypes (),
-               factoryConfig->getSupportedPlaybackTransformationFlags ()
+               factoryConfig->getSupportedPlaybackTransformationFlags (),
+               (factoryConfig->supportsStoringAudioFileChunks ()) ? kARATrue : kARAFalse
              }
 {
     ARA_INTERNAL_ASSERT (_factory.lowestSupportedApiGeneration >= kARAAPIGeneration_1_0_Draft);

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -2655,6 +2655,9 @@ PlugInEntry::PlugInEntry (const FactoryConfig* factoryConfig,
 {
     ARA_INTERNAL_ASSERT (_factory.lowestSupportedApiGeneration >= kARAAPIGeneration_1_0_Draft);
     ARA_INTERNAL_ASSERT (_factory.highestSupportedApiGeneration >= _factory.lowestSupportedApiGeneration);
+#if ARA_CPU_ARM
+    ARA_INTERNAL_ASSERT (_factory.highestSupportedApiGeneration >= kARAAPIGeneration_2_x_Draft);
+#endif
 
     ARA_INTERNAL_ASSERT (std::strlen (_factory.factoryID) > 5);             // at least "xx.y." needed to form a valid url-based unique ID
     ARA_INTERNAL_ASSERT (std::strlen (_factory.plugInName) > 0);

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -2732,7 +2732,7 @@ void PlugInEntry::initializeARAWithConfiguration (const ARAInterfaceConfiguratio
 
     const SizedStructPtr<ARAInterfaceConfiguration> ptr { config };
     ARA_VALIDATE_API_STRUCT_PTR (ptr, ARAInterfaceConfiguration);
-    ARA_VALIDATE_API_ARGUMENT (ptr, getFactory ()->lowestSupportedApiGeneration <= config->desiredApiGeneration);
+    ARA_VALIDATE_API_ARGUMENT (ptr, getFactory ()->lowestSupportedApiGeneration <= ptr->desiredApiGeneration);
     ARA_VALIDATE_API_ARGUMENT (ptr, ptr->desiredApiGeneration <= getFactory ()->highestSupportedApiGeneration);
 
     _usedApiGeneration = ptr->desiredApiGeneration;

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -1496,6 +1496,7 @@ void DocumentController::deactivateAudioSourceForUndoHistory (ARAAudioSourceRef 
     ARA_VALIDATE_API_STATE (_contentReaders.empty ());
 
     auto audioSource { fromRef (audioSourceRef) };
+    ARA_VALIDATE_API_ARGUMENT (audioSourceRef, isValidAudioSource (audioSource));
     if (deactivate != audioSource->isDeactivatedForUndoHistory ())
     {
         willDeactivateAudioSourceForUndoHistory (audioSource, deactivate);
@@ -1673,6 +1674,7 @@ void DocumentController::updatePlaybackRegionProperties (ARAPlaybackRegionRef pl
     // determine if the region sequence will change from this update
     auto currentSequence { playbackRegion->getRegionSequence () };
     auto newSequence { fromRef (properties->regionSequenceRef) };
+    ARA_VALIDATE_API_ARGUMENT (newSequence, isValidRegionSequence (newSequence));
 
     if (currentSequence && (currentSequence != newSequence))
         willRemovePlaybackRegionFromRegionSequence (currentSequence, playbackRegion);
@@ -1974,6 +1976,7 @@ ARAInt32 DocumentController::getContentReaderEventCount (ARAContentReaderRef con
 
     const auto contentReader { fromRef (contentReaderRef) };
     ARA_VALIDATE_API_ARGUMENT (contentReaderRef, isValidContentReader (contentReader));
+
     return contentReader->getEventCount ();
 }
 

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -1099,14 +1099,14 @@ void DocumentController::notifyModelUpdates () noexcept
     didNotifyModelUpdates ();
 }
 
-bool DocumentController::restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept
+bool DocumentController::restoreObjectsFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef, const ARARestoreObjectsFilter* filter) noexcept
 {
     ARA_LOG_HOST_ENTRY (this);
     ARA_VALIDATE_API_ARGUMENT (this, isValidDocumentController (this));
     ARA_VALIDATE_API_STATE (isHostEditingDocument ());
     ARA_VALIDATE_API_STATE (_contentReaders.empty ());
 
-    HostArchiveReader archiveReader (this, readerHostRef);
+    HostArchiveReader archiveReader (this, archiveReaderHostRef);
 
 #if ARA_VALIDATE_API_CALLS
     if (DocumentController::getUsedApiGeneration () >= kARAAPIGeneration_2_0_Final)
@@ -1127,14 +1127,14 @@ bool DocumentController::restoreObjectsFromArchive (ARAArchiveReaderHostRef read
     return doRestoreObjectsFromArchive (&archiveReader, &restoreObjectsFilter);
 }
 
-bool DocumentController::storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept
+bool DocumentController::storeObjectsToArchive (ARAArchiveWriterHostRef archiveWriterHostRef, const ARAStoreObjectsFilter* filter) noexcept
 {
     ARA_LOG_HOST_ENTRY (this);
     ARA_VALIDATE_API_ARGUMENT (this, isValidDocumentController (this));
     ARA_VALIDATE_API_STATE (!isHostEditingDocument ());
     ARA_VALIDATE_API_STATE (_contentReaders.empty ());
 
-    HostArchiveWriter archiveWriter (this, writerHostRef);
+    HostArchiveWriter archiveWriter (this, archiveWriterHostRef);
     if (filter)
     {
         for (ARASize i { 0 }; i < filter->audioSourceRefsCount; ++i)
@@ -1151,7 +1151,7 @@ bool DocumentController::storeObjectsToArchive (ARAArchiveWriterHostRef writerHo
     }
 }
 
-bool DocumentController::storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept
+bool DocumentController::storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef archiveWriterHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept
 {
     ARA_LOG_HOST_ENTRY (this);
     ARA_VALIDATE_API_ARGUMENT (this, isValidDocumentController (this));
@@ -1166,7 +1166,7 @@ bool DocumentController::storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostR
     ARA_VALIDATE_API_STATE (!isHostEditingDocument ());
     ARA_VALIDATE_API_STATE (_contentReaders.empty ());
 
-    HostArchiveWriter archiveWriter (this, writerHostRef);
+    HostArchiveWriter archiveWriter (this, archiveWriterHostRef);
     *documentArchiveID = nullptr;
     const auto result { doStoreAudioSourceToAudioFileChunk (&archiveWriter, audioSource, documentArchiveID, openAutomatically) };
     ARA_INTERNAL_ASSERT (*documentArchiveID != nullptr);
@@ -2269,9 +2269,9 @@ bool HostAudioReader::readAudioSamples (ARASamplePosition samplePosition, ARASam
 
 /*******************************************************************************/
 
-HostArchiveReader::HostArchiveReader (DocumentController* documentController, ARAArchiveReaderHostRef readerHostRef) noexcept
+HostArchiveReader::HostArchiveReader (DocumentController* documentController, ARAArchiveReaderHostRef archiveReaderHostRef) noexcept
 : _hostArchivingController { documentController->getHostArchivingController () },
-  _hostRef { readerHostRef }
+  _hostRef { archiveReaderHostRef }
 {}
 
 ARASize HostArchiveReader::getArchiveSize () const noexcept
@@ -2296,9 +2296,9 @@ ARAPersistentID HostArchiveReader::getDocumentArchiveID () const noexcept
 
 /*******************************************************************************/
 
-HostArchiveWriter::HostArchiveWriter (DocumentController* documentController, ARAArchiveWriterHostRef writerHostRef) noexcept
+HostArchiveWriter::HostArchiveWriter (DocumentController* documentController, ARAArchiveWriterHostRef archiveWriterHostRef) noexcept
 : _hostArchivingController { documentController->getHostArchivingController () },
-  _hostRef { writerHostRef }
+  _hostRef { archiveWriterHostRef }
 {}
 
 bool HostArchiveWriter::writeBytesToArchive (ARASize position, ARASize length, const ARAByte buffer[]) noexcept

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -2331,14 +2331,14 @@ std::vector<PlaybackRegion*> _convertPlaybackRegionsArray (const DocumentControl
     return playbackRegions;
 }
 
-std::vector<RegionSequence*> _convertRegionSequencesArray (const DocumentController* ARA_MAYBE_UNUSED_ARG (documentController), ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[])
+std::vector<RegionSequence*> _convertRegionSequencesArray (const DocumentController* ARA_MAYBE_UNUSED_ARG (documentController), ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[])
 {
     std::vector<RegionSequence*> regionSequences;
-    if (regionSequencesCount > 0)
+    if (regionSequenceRefsCount > 0)
     {
         ARA_VALIDATE_API_ARGUMENT (regionSequenceRefs, regionSequenceRefs != nullptr);
-        regionSequences.reserve (regionSequencesCount);
-        for (ARASize i { 0 }; i < regionSequencesCount; ++i)
+        regionSequences.reserve (regionSequenceRefsCount);
+        for (ARASize i { 0 }; i < regionSequenceRefsCount; ++i)
         {
             auto regionSequence { fromRef (regionSequenceRefs[i]) };
             ARA_VALIDATE_API_ARGUMENT (regionSequenceRefs[i], documentController->isValidRegionSequence (regionSequence));
@@ -2594,11 +2594,11 @@ void EditorView::notifySelection (SizedStructPtr<ARAViewSelection> selection) no
         doNotifySelection (&_viewSelection);
 }
 
-void EditorView::notifyHideRegionSequences (ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
+void EditorView::notifyHideRegionSequences (ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept
 {
     ARA_LOG_HOST_ENTRY (this);
     ARA_VALIDATE_API_ARGUMENT (this, DocumentController::isValidDocumentController (_documentController) && _documentController->isValidEditorView (this));
-    _hiddenRegionSequences = _convertRegionSequencesArray (_documentController, regionSequencesCount, regionSequenceRefs);
+    _hiddenRegionSequences = _convertRegionSequencesArray (_documentController, regionSequenceRefsCount, regionSequenceRefs);
 
 #if ARA_ENABLE_VIEW_UPDATE_LOG
     if (_hiddenRegionSequences.empty ())

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -1115,9 +1115,9 @@ bool DocumentController::restoreObjectsFromArchive (ARAArchiveReaderHostRef read
 
         ARA_VALIDATE_API_STATE ((documentArchiveID != nullptr) && (std::strlen (documentArchiveID) > 0));
 
-        bool isValidDocumentArchiveID { 0 == strcmp (documentArchiveID, getFactory ()->documentArchiveID) };
+        bool isValidDocumentArchiveID { 0 == std::strcmp (documentArchiveID, getFactory ()->documentArchiveID) };
         for (ARASize i { 0 }; !isValidDocumentArchiveID && (i < getFactory ()->compatibleDocumentArchiveIDsCount); ++i)
-            isValidDocumentArchiveID = (0 == strcmp (documentArchiveID, getFactory ()->compatibleDocumentArchiveIDs[i]));
+            isValidDocumentArchiveID = (0 == std::strcmp (documentArchiveID, getFactory ()->compatibleDocumentArchiveIDs[i]));
         ARA_VALIDATE_API_STATE (isValidDocumentArchiveID);
     }
 #endif

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -2702,7 +2702,7 @@ PlugInEntry::PlugInEntry (const FactoryConfig* factoryConfig,
     ARA_INTERNAL_ASSERT (_factory.lowestSupportedApiGeneration >= kARAAPIGeneration_1_0_Draft);
     ARA_INTERNAL_ASSERT (_factory.highestSupportedApiGeneration >= _factory.lowestSupportedApiGeneration);
 #if ARA_CPU_ARM
-    ARA_INTERNAL_ASSERT (_factory.highestSupportedApiGeneration >= kARAAPIGeneration_2_x_Draft);
+    ARA_INTERNAL_ASSERT (_factory.highestSupportedApiGeneration >= kARAAPIGeneration_2_X_Draft);
 #endif
 
     ARA_INTERNAL_ASSERT (std::strlen (_factory.factoryID) > 5);             // at least "xx.y." needed to form a valid url-based unique ID

--- a/PlugIn/ARAPlug.cpp
+++ b/PlugIn/ARAPlug.cpp
@@ -658,7 +658,7 @@ ARASamplePosition PlaybackRegion::getStartInAudioModificationSamples () const no
 
 ARASampleCount PlaybackRegion::getDurationInAudioModificationSamples () const noexcept
 {
-    return getEndInAudioModificationSamples() - getStartInAudioModificationSamples ();
+    return getEndInAudioModificationSamples () - getStartInAudioModificationSamples ();
 }
 
 ARASamplePosition PlaybackRegion::getEndInAudioModificationSamples () const noexcept

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -1779,7 +1779,7 @@ public:
 #if ARA_SUPPORT_VERSION_1
                                                                                 { return kARAAPIGeneration_1_0_Final; }
 #elif ARA_CPU_ARM
-                                                                                { return kARAAPIGeneration_2_x_Draft; }
+                                                                                { return kARAAPIGeneration_2_X_Draft; }
 #else
                                                                                 { return kARAAPIGeneration_2_0_Draft; }
 #endif

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -1687,7 +1687,7 @@ public:
     // Inherited public interface used by the C++ dispatcher, to be called by the ARAPlugInDispatch code exclusively.
     // Typically not overridden - need to call base class implementation if so.
     void notifySelection (SizedStructPtr<ARAViewSelection> selection) noexcept override;
-    void notifyHideRegionSequences (ARASize regionSequencesCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept override;
+    void notifyHideRegionSequences (ARASize regionSequenceRefsCount, const ARARegionSequenceRef regionSequenceRefs[]) noexcept override;
 #endif
 
 private:

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -1930,7 +1930,7 @@ public:
 private:
     // to be called by DocumentController during destruction exclusively
     friend class DocumentController;
-    void destroyDocumentController(DocumentController* documentController) const noexcept { _factoryConfig->destroyDocumentController(documentController); }
+    void destroyDocumentController (DocumentController* documentController) const noexcept { _factoryConfig->destroyDocumentController (documentController); }
 
 private:
     const FactoryConfig* const _factoryConfig;

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -1123,9 +1123,9 @@ public:
     void notifyModelUpdates () noexcept override;
 
     // Archiving
-    bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept override;
-    bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept override;
-    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept override;
+    bool restoreObjectsFromArchive (ARAArchiveReaderHostRef archiveReaderHostRef, const ARARestoreObjectsFilter* filter) noexcept override;
+    bool storeObjectsToArchive (ARAArchiveWriterHostRef archiveWriterHostRef, const ARAStoreObjectsFilter* filter) noexcept override;
+    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef archiveWriterHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept override;
 
     // Document Management
     void updateDocumentProperties (PropertiesPtr<ARADocumentProperties> properties) noexcept override;
@@ -1418,7 +1418,7 @@ private:
 class HostArchiveReader
 {
 public:
-    HostArchiveReader (DocumentController* documentController, ARAArchiveReaderHostRef readerHostRef) noexcept;
+    HostArchiveReader (DocumentController* documentController, ARAArchiveReaderHostRef archiveReaderHostRef) noexcept;
 
     ARASize getArchiveSize () const noexcept;                                                       //!< \copydoc ARAArchivingControllerInterface::getArchiveSize
     bool readBytesFromArchive (ARASize position, ARASize length, ARAByte buffer[]) const noexcept;  //!< \copydoc ARAArchivingControllerInterface::readBytesFromArchive
@@ -1438,7 +1438,7 @@ private:
 class HostArchiveWriter
 {
 public:
-    HostArchiveWriter (DocumentController* documentController, ARAArchiveWriterHostRef writerHostRef) noexcept;
+    HostArchiveWriter (DocumentController* documentController, ARAArchiveWriterHostRef archiveWriterHostRef) noexcept;
 
     bool writeBytesToArchive (ARASize position, ARASize length, const ARAByte buffer[]) noexcept;   //!< \copydoc ARAArchivingControllerInterface::writeBytesToArchive
     void notifyDocumentArchivingProgress (float value) noexcept;                                    //!< \copydoc ARAArchivingControllerInterface::notifyDocumentArchivingProgress

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -820,6 +820,11 @@ protected:
     virtual bool doRestoreObjectsFromArchive (HostArchiveReader* archiveReader, const RestoreObjectsFilter* filter) noexcept = 0;
     //! Override to implement storeObjectsToArchive().
     virtual bool doStoreObjectsToArchive (HostArchiveWriter* archiveWriter, const StoreObjectsFilter* filter) noexcept = 0;
+    //! Override to customize storeAudioSourceToAudioFileChunk() if needed.
+    //! The default implementation calls doStoreObjectsToArchive() with an appropriate StoreObjectsFilter
+    //! and sets openAutomatically to false - check if your internal data format allows for optimizing
+    //! this according to the criteria documented for storeAudioSourceToAudioFileChunk().
+    virtual bool doStoreAudioSourceToAudioFileChunk (HostArchiveWriter* archiveWriter, AudioSource* audioSource, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept;
     //@}
 
     //! @name Document Management Hooks
@@ -1120,6 +1125,7 @@ public:
     // Archiving
     bool restoreObjectsFromArchive (ARAArchiveReaderHostRef readerHostRef, const ARARestoreObjectsFilter* filter) noexcept override;
     bool storeObjectsToArchive (ARAArchiveWriterHostRef writerHostRef, const ARAStoreObjectsFilter* filter) noexcept override;
+    bool storeAudioSourceToAudioFileChunk (ARAArchiveWriterHostRef writerHostRef, ARAAudioSourceRef audioSourceRef, ARAPersistentID* documentArchiveID, bool* openAutomatically) noexcept override;
 
     // Document Management
     void updateDocumentProperties (PropertiesPtr<ARADocumentProperties> properties) noexcept override;
@@ -1808,6 +1814,9 @@ public:
 
     //! \copydoc ARAFactory::supportedPlaybackTransformationFlags
     virtual ARAPlaybackTransformationFlags getSupportedPlaybackTransformationFlags () const noexcept { return kARAPlaybackTransformationNoChanges; }
+
+    //! \copydoc ARAFactory::supportsStoringAudioFileChunks
+    virtual bool supportsStoringAudioFileChunks () const noexcept { return false; }
 };
 
 
@@ -1925,7 +1934,7 @@ private:
 
 private:
     const FactoryConfig* const _factoryConfig;
-    const SizedStruct<ARA_STRUCT_MEMBER (ARAFactory, supportedPlaybackTransformationFlags)> _factory;
+    const SizedStruct<ARA_STRUCT_MEMBER (ARAFactory, supportsStoringAudioFileChunks)> _factory;
     ARAAPIGeneration _usedApiGeneration { 0 };
 
     ARA_DISABLE_COPY_AND_MOVE (PlugInEntry)

--- a/PlugIn/ARAPlug.h
+++ b/PlugIn/ARAPlug.h
@@ -1772,6 +1772,8 @@ public:
     virtual ARAAPIGeneration getLowestSupportedApiGeneration () const noexcept
 #if ARA_SUPPORT_VERSION_1
                                                                                 { return kARAAPIGeneration_1_0_Final; }
+#elif ARA_CPU_ARM
+                                                                                { return kARAAPIGeneration_2_x_Draft; }
 #else
                                                                                 { return kARAAPIGeneration_2_0_Draft; }
 #endif

--- a/Utilities/ARAStdVectorUtilities.h
+++ b/Utilities/ARAStdVectorUtilities.h
@@ -54,7 +54,7 @@ inline std::vector<T> const& vector_cast (std::vector<U> const& container) noexc
 //@{
 
 template <typename T, typename U, typename std::enable_if<std::is_convertible<T, U>::value || std::is_convertible<U, T>::value, bool>::type = true>
-inline bool find_erase (std::vector<T>& container, const U element) noexcept
+inline bool find_erase (std::vector<T>& container, const U& element) noexcept
 {
     const auto it { std::find (container.begin (), container.end (), element) };
     if (it == container.end ())
@@ -71,7 +71,7 @@ inline bool find_erase (std::vector<T>& container, const U element) noexcept
 //@{
 
 template <typename T, typename U, typename std::enable_if<std::is_convertible<T, U>::value || std::is_convertible<U, T>::value, bool>::type = true>
-inline bool contains (std::vector<T> const& container, const U element) noexcept
+inline bool contains (std::vector<T> const& container, const U& element) noexcept
 {
     return std::find (container.begin (), container.end (), element) != container.end ();
 }


### PR DESCRIPTION
This fixes compile errors on arm64 due to apparent spelling mismatches of kARAAPIGeneration_2_X (vs. ..._2_x).